### PR TITLE
Removed close argument for ofThread.stopThread()

### DIFF
--- a/src/ofxFaceTrackerThreaded.h
+++ b/src/ofxFaceTrackerThreaded.h
@@ -12,7 +12,7 @@ public:
 	,meanObjectPointsReady(false) {
 	}
 	~ofxFaceTrackerThreaded() {
-		stopThread(false);
+		stopThread();
 		ofSleepMillis(500);
 	}
 	void setup() {


### PR DESCRIPTION
ofThread doesn't need the bool close argument anymore.
https://github.com/openframeworks/openFrameworks/commit/c6a00e66e69ed6af630bac98108cd020cf3030d6
