### PR TITLE
Changed path to python

### DIFF
--- a/update-projects.py
+++ b/update-projects.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 import glob, re, shutil, fileinput, os
 


### PR DESCRIPTION
Changed path to python and permission of file so you can run update with ./update-projects.py.
# !/usr/bin/env python should always point to the users python, whereas /bin/python might fail if Python is installed somewhere else (as is the case on my system).
