### PR TITLE
ofxFaceTrackerThreaded Bug fixes

### DIFF
--- a/src/ofxFaceTracker.cpp
+++ b/src/ofxFaceTracker.cpp
@@ -80,6 +80,10 @@ void ofxFaceTracker::setup() {
 	con = IO::LoadCon(conFile.c_str());  // not being used right now
 }
 
+void ofxFaceTracker::exit() {
+
+}
+
 bool ofxFaceTracker::update(Mat image) {	
 	if(rescale == 1) {
 		im = image; 
@@ -278,6 +282,8 @@ ofxFaceTracker::Direction ofxFaceTracker::getDirection() const {
 		case 0: return FACING_FORWARD;
 		case 1: return FACING_LEFT;
 		case 2: return FACING_RIGHT;
+        default:
+            return FACING_UNKNOWN;
 	}
 }
 

--- a/src/ofxFaceTracker.h
+++ b/src/ofxFaceTracker.h
@@ -23,6 +23,7 @@ class ofxFaceTracker {
 public:
 	ofxFaceTracker();
 	void setup();
+	virtual void exit();
 	virtual bool update(cv::Mat image);
 	void draw(bool drawLabels = false) const;
 	void reset();

--- a/src/ofxFaceTrackerThreaded.h
+++ b/src/ofxFaceTrackerThreaded.h
@@ -12,11 +12,17 @@ public:
 	,meanObjectPointsReady(false) {
 	}
 	~ofxFaceTrackerThreaded() {
-		stopThread();
-		ofSleepMillis(500);
+		if(isThreadRunning()) {
+			stopThread();
+			ofSleepMillis(500);
+		}
+	}
+	void exit() {
+		waitForThread(true);
 	}
 	void setup() {
 		failed = true;
+		failedMiddle = true;
 		ofxFaceTracker::setup();
 		startThread(true, false);
 	}
@@ -39,19 +45,19 @@ public:
 		return objectPointsMatFront;
 	}
 	ofVec2f getImagePoint(int i) const {
-		if(failed) {
+		if(failed || imagePointsFront.size() == 0) {
 			return ofVec2f();
 		}
 		return imagePointsFront[i];
 	}
 	ofVec3f getObjectPoint(int i) const {
-		if(failed) {
+		if(failed || objectPointsFront.size() == 0) {
 			return ofVec3f();
 		}
 		return objectPointsFront[i];
 	}
 	ofVec3f getMeanObjectPoint(int i) const {
-		if(meanObjectPointsReady) {
+		if(meanObjectPointsReady || meanObjectPointsFront.size() != 0) {
 			return meanObjectPointsFront[i];
 		} else {
 			return ofVec3f();
@@ -74,6 +80,12 @@ protected:
 	void threadedFunction() {
 		ofxFaceTracker* threadedTracker = new ofxFaceTracker();
 		threadedTracker->setup();
+		
+		if(isThreadRunning()) {
+			ofLog(OF_LOG_NOTICE, "ofxFaceTracker::Thread running");
+		} else {
+			ofLog(OF_LOG_ERROR, "ofxFaceTracker::Error Failed to start thread");
+		}
 		while(isThreadRunning()) {
 			dataMutex.lock();
 			needsUpdatingBack = needsUpdatingFront;


### PR DESCRIPTION
- Fixed crash on startup for ofxFaceTrackerThreaded for iOS/Slow devices by returning default datatypes instead of clashing against NULL's or empty vectors. 
  Problem was the ofxFaceTrackerThreaded::setup was not completing before the rest of the app started using it. So if the oF app running in the other thread asks the ofxFaceTracker for information via a function which may lead to crash if variables were NULL or 0 in size. 
- Fixed uninitialised variable ‘failedMiddle’. 
  Problem: Causing a false positive reading for the tracker.getFound() in the first loop in LLVM / iOS.
  Solution: Making sure it is a true (so YES to fail) at the start fixes this.
