### PR TITLE
ofxFaceTrackerThreaded fixes

### DIFF
--- a/example-threaded/ofApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/example-threaded/ofApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ofApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/example-threaded/src/testApp.cpp
+++ b/example-threaded/src/testApp.cpp
@@ -11,6 +11,10 @@ void testApp::setup() {
 	tracker.setup();
 }
 
+void testApp::exit() {
+    tracker.waitForThread();
+}
+
 void testApp::update() {
 	cam.update();
 	if(cam.isFrameNew()) {
@@ -32,7 +36,7 @@ void testApp::draw() {
 		tracker.draw();
 		
 		//easyCam.begin();
-		ofSetupScreenOrtho(640, 480, OF_ORIENTATION_UNKNOWN, true, -1000, 1000);
+		ofSetupScreenOrtho(640, 480, -1000, 1000);
 		ofTranslate(640 / 2, 480 / 2);
 		applyMatrix(rotationMatrix);
 		ofScale(5,5,5);

--- a/example-threaded/src/testApp.h
+++ b/example-threaded/src/testApp.h
@@ -10,6 +10,7 @@ using namespace cv;
 class testApp : public ofBaseApp {
 public:
 	void setup();
+    void exit();
 	void update();
 	void draw();
 	void keyPressed(int key);

--- a/src/ofxFaceTrackerThreaded.h
+++ b/src/ofxFaceTrackerThreaded.h
@@ -20,7 +20,7 @@ public:
 		failed = true;
         failedMiddle = true;
 		ofxFaceTracker::setup();
-		startThread(true, false);
+		startThread(true);
 	}
 	bool update(cv::Mat image) {
 		dataMutex.lock();


### PR DESCRIPTION
Fixes issues #74
- Fixed crash on startup for ofxFaceTrackerThreaded for iOS/Slow
  devices by returning default datatypes instead of clashing against
  NULL's or empty vectors.
  Problem was the ofxFaceTrackerThreaded::setup was not completing before
  the rest of the app started using it. So if the oF app running in the
  other thread asks the ofxFaceTracker for information via a function
  which may lead to crash if variables were NULL or 0 in size.
- Fixed uninitialised variable ‘failedMiddle’.
  Problem: Causing a false positive reading for the tracker.getFound() in
  the first loop in LLVM / iOS.
  Solution: Making sure it is a true (so YES to fail) at the start fixes
  this.
- Adds ofLog Errors if thread is not stopped before destructor and if the case exists where the thread is not started.
