### PR TITLE
Removes orientation and vflip parameters in ofSetupScreenOrtho

### DIFF
--- a/FaceOSC/src/testApp.cpp
+++ b/FaceOSC/src/testApp.cpp
@@ -26,13 +26,13 @@ void testApp::loadSettings() {
 	camHeight = xml.getValue("height", 480);
 	cam.initGrabber(camWidth, camHeight);
 	xml.popTag();
-    
+
 	xml.pushTag("movie");
 	if(xml.getNumTags("filename") > 0) {
 		string filename = ofToDataPath((string) xml.getValue("filename", ""));
 		if(!movie.loadMovie(filename)) {
 			ofLog(OF_LOG_ERROR, "Could not load movie \"%s\", reverting to camera input", filename.c_str());
-			bUseCamera = true; 
+			bUseCamera = true;
 		}
 		movie.play();
 	}
@@ -41,11 +41,11 @@ void testApp::loadSettings() {
 		bUseCamera = true;
 	}
 	if(xml.getNumTags("volume") > 0) {
-		float movieVolume = ofClamp(xml.getValue("volume", 1.0), 0, 1.0); 
+		float movieVolume = ofClamp(xml.getValue("volume", 1.0), 0, 1.0);
 		movie.setVolume(movieVolume);
 	}
 	if(xml.getNumTags("speed") > 0) {
-		float movieSpeed = ofClamp(xml.getValue("speed", 1.0), -16, 16); 
+		float movieSpeed = ofClamp(xml.getValue("speed", 1.0), -16, 16);
 		movie.setSpeed(movieSpeed);
 	}
 	bPaused = false;
@@ -61,7 +61,7 @@ void testApp::loadSettings() {
 		ofSetWindowShape(movieWidth, movieHeight);
 		setVideoSource(false);
 	}
-    
+
 	xml.pushTag("face");
 	if(xml.getNumTags("rescale")) {
 		tracker.setRescale(xml.getValue("rescale", 1.));
@@ -102,7 +102,7 @@ void testApp::setup() {
 void testApp::update() {
 	if(bPaused)
 		return;
-        
+
 	videoSource->update();
 	if(videoSource->isFrameNew()) {
 		tracker.update(toCv(*videoSource));
@@ -122,9 +122,9 @@ void testApp::draw() {
 			ofSetLineWidth(1);
 			//tracker.draw();
 			tracker.getImageMesh().drawWireframe();
-		
+
 			ofPushView();
-			ofSetupScreenOrtho(sourceWidth, sourceHeight, OF_ORIENTATION_UNKNOWN, true, -1000, 1000);
+			ofSetupScreenOrtho(sourceWidth, sourceHeight, -1000, 1000);
 			ofVec2f pos = tracker.getPosition();
 			ofTranslate(pos.x, pos.y);
 			applyMatrix(rotationMatrix);
@@ -135,7 +135,7 @@ void testApp::draw() {
 	} else {
 		ofDrawBitmapString("searching for face...", 10, 20);
 	}
-    
+
 	if(bPaused) {
 		ofSetColor(255, 0, 0);
 		ofDrawBitmapString( "paused", 10, 32);

--- a/example-advanced/src/testApp.cpp
+++ b/example-advanced/src/testApp.cpp
@@ -5,9 +5,9 @@ using namespace ofxCv;
 void testApp::setup() {
 	ofSetVerticalSync(true);
 	ofSetDrawBitmapMode(OF_BITMAPMODE_MODEL_BILLBOARD);
-	
+
 	cam.initGrabber(640, 480);
-	
+
 	tracker.setup();
 }
 
@@ -26,13 +26,13 @@ void testApp::draw() {
 	ofSetColor(255);
 	cam.draw(0, 0);
 	ofDrawBitmapString(ofToString((int) ofGetFrameRate()), 10, 20);
-	
+
 	if(tracker.getFound()) {
 		ofSetLineWidth(1);
 		tracker.draw();
-		
+
 		//easyCam.begin();
-		ofSetupScreenOrtho(640, 480, OF_ORIENTATION_UNKNOWN, true, -1000, 1000);
+		ofSetupScreenOrtho(640, 480, -1000, 1000);
 		ofTranslate(640 / 2, 480 / 2);
 		applyMatrix(rotationMatrix);
 		ofScale(5,5,5);

--- a/example-extraction/src/testApp.cpp
+++ b/example-extraction/src/testApp.cpp
@@ -19,13 +19,13 @@ void testApp::draw() {
 	ofSetColor(255);
 	cam.draw(0, 0);
 	ofDrawBitmapString(ofToString((int) ofGetFrameRate()), 10, 20);
-	
+
 	if(tracker.getFound()) {
 		tracker.draw();
 		ofMesh objectMesh = tracker.getObjectMesh();
 		ofMesh meanMesh = tracker.getMeanObjectMesh();
-		
-		ofSetupScreenOrtho(640, 480, OF_ORIENTATION_DEFAULT, true, -1000, 1000);
+
+		ofSetupScreenOrtho(640, 480, -1000, 1000);
 		ofTranslate(100, 100);
 		ofScale(5,5,5);
 		cam.getTextureReference().bind();


### PR DESCRIPTION
Removes orientation and vflip parameters from ofSetupScreenOrtho() calls in the examples.
These two parameters have been removed in OF 0.8.0. See [CHANGELOG.md](https://github.com/openframeworks/openFrameworks/blob/master/CHANGELOG.md).

My editor also automatically removed a bunch of trailing whitespace. I can create a new pull request without this if you'd prefer.