### PR TITLE
Optional force sleep time between thread runs

### DIFF
--- a/src/ofxFaceTrackerThreaded.h
+++ b/src/ofxFaceTrackerThreaded.h
@@ -17,9 +17,10 @@ public:
             ofLog(OF_LOG_ERROR, "ofxFaceTrackerThreaded :: Thread was not stopped. You must call the trackers waitForThread() in ofApp::exit() or exit() of class that holds this object.");
         }
 	}
-	void setup() {
+	void setup(int _forceWaitTime = 0) {
 		failed = true;
         failedMiddle = true;
+		forceWaitTime = _forceWaitTime;
 		ofxFaceTracker::setup();
 		startThread(true);
 	}
@@ -118,6 +119,8 @@ protected:
 			scale = threadedTracker->getScale();
 			objectPointsMatMiddle = threadedTracker->getObjectPointsMat();
 			dataMutex.unlock();
+
+			ofSleepMillis(forceWaitTime);
 		}
 		delete threadedTracker;
 	}
@@ -136,4 +139,6 @@ protected:
 	float scale;
 	glm::vec2 position;
 	cv::Mat objectPointsMatBack, objectPointsMatMiddle, objectPointsMatFront; 
+
+	int forceWaitTime;
 };


### PR DESCRIPTION
In some cases where high framerate tracking is not required (e.g. the "main work" is being done on the applications' other threads, and you just need a check for faces every half second or so), then with threaded face tracking, it can be very useful to sleep the thread for a few milliseconds in its loop, to effectively make it run at a lower framerate than the main application.

This pull request incorporates an optional `int forceWaitTime` into the `setup` function for the threaded face tracker, without breaking the more usual use case.